### PR TITLE
Added bower.json for bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "articles",
+  "version": "0.2.1",
+  "authors": [
+    "Chad Kirby"
+  ],
+  "private": false,
+  "main": "lib/Articles.js",
+  "ignore": [],
+  "dependencies": {}
+}


### PR DESCRIPTION
Installing via custom repo works, but Grunt Bower Install doesn’t support it if it doesn’t have a bower.json